### PR TITLE
feat: share as LucideIconData code

### DIFF
--- a/src/components/IconEditor/Menu.tsx
+++ b/src/components/IconEditor/Menu.tsx
@@ -248,7 +248,7 @@ const Menu = ({
             className="gap-1.5"
           >
             <BracesIcon />
-            Copy LucideIconData code to clipboard
+            Copy lucide icon data code to clipboard
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>

--- a/src/components/IconEditor/Menu.tsx
+++ b/src/components/IconEditor/Menu.tsx
@@ -14,20 +14,21 @@ import {
 } from "@/components/ui/menubar";
 import optimize from "@/components/IconEditor/optimize";
 import {
+  BracesIcon,
   BrushIcon,
+  createLucideIcon,
   DownloadIcon,
+  DraftingCompassIcon,
   FolderUpIcon,
   LogOutIcon,
   MaximizeIcon,
   MinimizeIcon,
   MoonIcon,
   RedoIcon,
-  TextSelectionIcon,
-  DraftingCompassIcon,
   SunIcon,
+  TextSelectionIcon,
   UndoIcon,
   WandSparklesIcon,
-  createLucideIcon,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import format from "./format";
@@ -36,6 +37,7 @@ import { signOut, useSession } from "next-auth/react";
 import { useQueryState } from "next-usequerystate";
 import arcify from "./arcify";
 import { toast } from "sonner";
+import { toLucideIconDataCode } from "./toLucideIconDataCode";
 
 const ColorfulDownloadIcon = createLucideIcon("ColorfulDownloadIcon", [
   ["path", { stroke: "#1982c4", d: "M 12 15 L 12 3" }],
@@ -238,6 +240,15 @@ const Menu = ({
           >
             <TextSelectionIcon />
             Copy preview embed code to clipboard
+          </MenubarItem>
+          <MenubarItem
+            onClick={() => {
+              toLucideIconDataCode(value, name).then(data => window.navigator.clipboard.writeText(data))
+            }}
+            className="gap-1.5"
+          >
+            <BracesIcon />
+            Copy LucideIconData code to clipboard
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>

--- a/src/components/IconEditor/toLucideIconDataCode.ts
+++ b/src/components/IconEditor/toLucideIconDataCode.ts
@@ -1,4 +1,5 @@
 import svgson from "svgson";
+import { camelCase, upperFirst } from "lodash";
 
 export type LucideIconNode = readonly [string, Record<string, string>]
   | readonly [string, Record<string, string>, LucideIconNode[]];
@@ -12,6 +13,6 @@ export const toLucideIconDataCode = async (svg: string, name?: string | null): P
 
   const parsed = await svgson.parse(svg);
   return `
-export const ${name ?? 'Foobar'}Icon = ${JSON.stringify(parsed.children.map(mapNode), undefined, 2)};
+export const ${upperFirst(camelCase(name ?? 'foobar'))}Icon = ${JSON.stringify(parsed.children.map(mapNode), undefined, 2)};
 `;
 }

--- a/src/components/IconEditor/toLucideIconDataCode.ts
+++ b/src/components/IconEditor/toLucideIconDataCode.ts
@@ -1,0 +1,17 @@
+import svgson from "svgson";
+
+export type LucideIconNode = readonly [string, Record<string, string>]
+  | readonly [string, Record<string, string>, LucideIconNode[]];
+
+export const toLucideIconDataCode = async (svg: string, name?: string | null): Promise<string> => {
+  function mapNode(node: svgson.INode): LucideIconNode {
+    return node.children?.length ?? 0 > 0
+      ? [node.name, node.attributes, node.children?.map(mapNode)]
+      : [node.name, node.attributes];
+  }
+
+  const parsed = await svgson.parse(svg);
+  return `
+export const ${name ?? 'Foobar'}Icon = ${JSON.stringify(parsed.children.map(mapNode), undefined, 2)};
+`;
+}


### PR DESCRIPTION
Allows copying the icon as a `LucideIconData` const.